### PR TITLE
Enable support for multiple suites

### DIFF
--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -47,7 +47,13 @@ class JsonRenderer implements RendererInterface
     public function getResult($asString = true)
     {
         if ($asString) {
-            return json_encode(array_pop($this->result));
+            $mergedResultArray= [];
+
+            while ($suiteResultItem = array_pop($this->result)) {
+                $mergedResultArray = array_merge($mergedResultArray, $suiteResultItem);
+            }
+
+            return json_encode($mergedResultArray);
         }
 
         return $this->result;


### PR DESCRIPTION
When rendering the result array only the first suite is taken.

This patch merges the results together before rendering so all suites are processed.

Fixes https://github.com/Vanare/behat-cucumber-formatter/issues/12