### PR TITLE
Fix for empty suites

### DIFF
--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -34,7 +34,9 @@ class JsonRenderer implements RendererInterface
 
         if (is_array($suites)) {
             foreach ($suites as $suite) {
-                array_push($this->result, $this->processSuite($suite));
+                if (!empty($this->processSuite($suite))) {
+                    array_push($this->result, $this->processSuite($suite));
+                }
             }
         }
     }


### PR DESCRIPTION

![capture](https://user-images.githubusercontent.com/511489/35527445-6b90fed8-0533-11e8-92a8-194b3473f65f.PNG)
If you have multiple test suites and you run the behat tests with @Tag, the json output will be an empty object if the last suite doesn't have any tests to run (no @Tag in the feature file for that suite is present)