### PR TITLE
Embed step arguments in json output

### DIFF
--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -217,12 +217,16 @@ class JsonRenderer implements RendererInterface
     }
 
     /**
-     * @param array $arguments
+     * @param mixed $arguments
      *
-     * @return array
+     * @return mixed
      */
-    protected function processArguments(array $arguments)
+    protected function processArguments($arguments)
     {
+        if (false === is_array($arguments)) {
+            return $arguments;
+        }
+
         return array_map(function ($argument) {
             return (string) $argument;
         }, $arguments);

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -4,7 +4,6 @@ namespace Vanare\BehatCucumberJsonFormatter\Renderer;
 
 use Vanare\BehatCucumberJsonFormatter\Formatter\FormatterInterface;
 use Vanare\BehatCucumberJsonFormatter\Node;
-use Vanare\BehatCucumberJsonFormatter\Renderer\RendererInterface;
 
 class JsonRenderer implements RendererInterface
 {
@@ -151,6 +150,7 @@ class JsonRenderer implements RendererInterface
             'line' => $step->getLine(),
             'match' => $step->getMatch(),
             'result' => $step->getProcessedResult(),
+            'arguments' => $this->processArguments($step->getArguments()),
         ];
 
         if (count($step->getEmbeddings())) {
@@ -214,5 +214,17 @@ class JsonRenderer implements RendererInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return array
+     */
+    protected function processArguments(array $arguments)
+    {
+        return array_map(function ($argument) {
+            return (string) $argument;
+        }, $arguments);
     }
 }


### PR DESCRIPTION
This might be usefull when testing an API for instance.

Use case:
```gherkin
Feature:
    Scenario:
        Given I prepare a "POST" request on "/api/users" with body:
        {
            "username": "john.doe"
        }
        When I send the request
        Then I sould receive a 201 response containing the following json:
        """
        {
            "id": 1,
            "username": "john.doe"
        }
        """
```